### PR TITLE
delete app.configure(feathers.errors())

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -19,8 +19,6 @@ var app = feathers()
 // Connect to the db, create and register a Feathers service.
 app.use('todos', mongooseService('todo', Todo));
 
-app.configure(feathers.errors());
-
 // Start the server.
 var port = 8080;
 app.listen(port, function() {


### PR DESCRIPTION
 In Readme.md file there is no "app.configure(feathers.error())
but in examples/basic.js there is such call.

Was getting below error:
==================================
app.configure(feathers.errors());
                        ^

TypeError: feathers.errors is not a function
    at Object.<anonymous> (C:\gitProject\feathers-mongoose\examples\basic.js:22:25)
    at Module._compile (module.js:398:26)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:430:10)
    at startup (node.js:141:18)
    at node.js:980:3
==================================

in Readme.md
==================================
// Connect to the db, create and register a Feathers service.
app.use('todos', new mongooseService('todo', Todo));

// Start the server.
var port = 8080;
==================================