### PR TITLE
Add toObject hook for documents.

### DIFF
--- a/lib/feathers-mongoose.js
+++ b/lib/feathers-mongoose.js
@@ -18,7 +18,7 @@ var MongooseService = Proto.extend({
     this.options = _.extend({}, options);
     this.type = 'mongoose';
     
-    // Add feathers-hooks compatibility.
+    // Add feathers-hooks definitions.
     this.before = entity.before || undefined;
     this.after = entity.after || undefined;
 
@@ -267,5 +267,5 @@ module.exports = function(modelName, schema, options) {
 };
 
 module.exports.Service = MongooseService;
-
 module.exports.mongoose = mongoose;
+module.exports.hooks = require('./hooks');

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,0 +1,46 @@
+/**
+ * The `toObject` hook converts the response to a plain js object instead of a 
+ * Mongoose model instance. It can only be used as an `after` hook.
+ * 
+ * This hook is configurable as a function. You can call it with arguments that 
+ * will be passed to the toObject method on the document. 
+ * For example: `toObject({serialize: true, virtuals: true})`
+ * 
+ * It can also be called directly, without a configuration, which will use the 
+ * default options as specified below. For example: `toObject`
+ * 
+ * @param  {Object} options The same options available to Mongoose documents:
+ *                          http://mongoosejs.com/docs/api.html#document_Document-toObject
+ * 		`options.`getters apply all getters (path and virtual getters)
+ * 		`options.virtuals` apply virtual getters (can override getters option)
+ *  	`options.minimize` remove empty objects (defaults to true)
+ *   	`options.transform` a transform function to apply to the resulting 
+ *   											document before returning
+ *    `options.depopulate` depopulate any populated paths, replacing them with 
+ *    										 their original refs (defaults to false)
+ *    `options.versionKey` whether to include the version key (defaults to true)
+ *    `options.retainKeyOrder` keep the order of object keys. If this is set to 
+ *    												 true, Object.keys(new Doc({ a: 1, b: 2}).toObject()) 
+ *    												 will always produce ['a', 'b'] (defaults to false)
+ * @return {Object}  The hook object with the result as a plain js object.
+ */
+exports.toObject = function(options, fn) {
+  if(typeof fn === 'function') {
+    throw new Error('Please use the hook as a function.');
+  }
+
+  function convert(obj){
+    return obj.toObject(options);
+  }
+
+  options = options || {};
+  return function(hook, next) {
+    if (Array.isArray(hook.result)) {
+      hook.result = hook.result.map(convert);
+    } else {
+      hook.result = convert(hook.result);
+    }
+    return next();
+  };
+};
+

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "author": "Feathers <hello@feathersjs.com> (http://feathersjs.com)",
   "contributors": [
     "Eric Kryski <e.kryski@gmail.com> (http://erickryski.com)",
-    "Glavin Wiechert <glavin.wiechert@gmail.com> (https://github.com/Glavin001)"
+    "Glavin Wiechert <glavin.wiechert@gmail.com> (https://github.com/Glavin001)",
+    "Marshall Thompson <marshall@creativeideal.net> (https://github.com/marshallswain)"
   ],
   "main": "lib/feathers-mongoose.js",
   "scripts": {
@@ -51,7 +52,8 @@
   "devDependencies": {
     "body-parser": "^1.13.2",
     "chai": "^3.0.0",
-    "feathers": "^1.1.0",
+    "feathers": "^1.3.0",
+    "feathers-hooks": "^0.5.1",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5"
   }


### PR DESCRIPTION
Includes tests and upgrades feathers version to 1.3.0.  One test is being skipped because I can't figure out how to test for the error thrown inside the hook when it's not used/initialized as a function.

Fixes #29 and #25, once published to npm.