### PR TITLE
Documenting the toObject hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,20 @@ query: {
 }
 ```
 
-> **Note:** Typically you can only populate one level deeep.
+> **Note:** Typically you can only populate one level deep.
+
+
+## Modifying retrieved data
+The records returned from a query are Mongoose documents, so they can't be modified directly (You won't be able to delete properties from them).  To get around this, you can use the included `toObject` hook to convert the Mongoose documents into plain objects.  Let's modify the before-hooks setup in the feathers-hooks example, above, to this:
+
+```js
+app.service('todos').before({
+  all: [feathersMongoose.hooks.toObject({})]
+});
+```
+
+The `toObject` hook must be called as a function and accepts a configuration object with any of the options supported by [Mongoose's toObject method](http://mongoosejs.com/docs/api.html#document_Document-toObject).
+
 
 ## Changelog
 ### 3.0.0

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -27,7 +27,7 @@
 
 export function toObject(options, hookFunction) {
   if (typeof hookFunction === 'function') {
-    throw new Error('Please use the hook as a function.');
+    throw new Error('Please use the toObject hook as a function.');
   }
 
   options = options || {};

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -28,7 +28,7 @@ describe('Feathers Mongoose Hooks', () => {
     it('throws an error if hook is not a function', () => {
       let options = { foo: 'bar' };
       let fn = function(){};
-      expect(hooks.toObject.bind(null, options, fn)).to.throw('Please use the hook as a function.');
+      expect(hooks.toObject.bind(null, options, fn)).to.throw('Please use the toObject hook as a function.');
     });
 
     it.skip('The toObject hook converts arrays of mongoose model instances to plain objects.', done => {


### PR DESCRIPTION
@ekryski Great update!  This is the only thing I think was missing.

Also includes small typo fix: deeep -> deep.