### PR TITLE
Use internal methods instead of service methods directly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "plugins": ["transform-object-assign", "add-module-exports"],
+  "plugins": [ "add-module-exports" ],
   "presets": [ "es2015" ]
 }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ app.listen(port, function() {
 You can run this example by using `node examples/app` and going to [localhost:3030/todos](http://localhost:3030/todos). You should see an empty array. That's because you don't have any Todos yet but you now have full CRUD for your new todos service, including mongoose validations!
 
 ## Changelog
+
+### 3.1.0
+
+- Use internal methods instead of service methods directly
+
 ### 3.0.0
+
 - Compatibility with Feathers 2.x
 - Changing how a service is initialized
 - Removing mongoose as a bundled dependency
@@ -117,6 +123,7 @@ You can run this example by using `node examples/app` and going to [localhost:30
 - Updating documentation and example.
 
 ### 2.0.0
+
 - Consistency with other service adapters
 - Compatibility with Feathers 1.0+
 - Adequate tests
@@ -129,9 +136,11 @@ You can run this example by using `node examples/app` and going to [localhost:30
     - $populate
 
 ### 0.1.1
+
 - First working release
 
 ### 0.1.0
+
 - Initial release.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -54,14 +54,13 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "feathers-errors": "^1.1.5",
-    "feathers-query-filters": "^1.5.0",
+    "feathers-query-filters": "^1.5.1",
     "uberproto": "^1.1.2"
   },
   "devDependencies": {
     "babel-cli": "^6.1.2",
     "babel-core": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.1.1",
-    "babel-plugin-transform-object-assign": "^6.1.18",
     "babel-preset-es2015": "^6.1.2",
     "body-parser": "^1.14.1",
     "chai": "^3.4.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+if(!global._babelPolyfill) { require('babel-polyfill'); }
+
 import * as hooks from './hooks';
 import service from './service';
 


### PR DESCRIPTION
This is for https://github.com/feathersjs/feathers/issues/218. Basically, if an adapter uses its own service methods internally (like doing a `get` after removing an item) they can't be the original service methods (like `get`, `create`, `find` etc.) directly since those can be modified by Feathers with mixins and hooks and we do not want those to run in that case.

For this adapter we now provide an internal `_get`, `_find` (that ignores pagination) and `_getOrFind` (for patch and remove many).