### PR TITLE
Fix for toObject hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "compile": "rm -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "start": "node example/app",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
@@ -74,6 +74,7 @@
     "mocha": "^2.3.3",
     "mongoose": "^4.1.0",
     "nsp": "^2.2.0",
+    "rimraf": "^2.5.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,37 +1,40 @@
 /**
- * The `toObject` hook converts the response to a plain js object instead of a 
+ * The `toObject` hook converts the response to a plain js object instead of a
  * Mongoose model instance. It can only be used as an `after` hook.
- * 
- * This hook is configurable as a function. You can call it with arguments that 
- * will be passed to the toObject method on the document. 
+ *
+ * This hook is configurable as a function. You can call it with arguments that
+ * will be passed to the toObject method on the document.
  * For example: `toObject({serialize: true, virtuals: true})`
- * 
- * It can also be called directly, without a configuration, which will use the 
+ *
+ * It can also be called directly, without a configuration, which will use the
  * default options as specified below. For example: `toObject`
- * 
+ *
  * @param  {Object} options The same options available to Mongoose documents:
  *                          http://mongoosejs.com/docs/api.html#document_Document-toObject
  *    `options.`getters apply all getters (path and virtual getters)
  *    `options.virtuals` apply virtual getters (can override getters option)
  *    `options.minimize` remove empty objects (defaults to true)
- *    `options.transform` a transform function to apply to the resulting 
+ *    `options.transform` a transform function to apply to the resulting
  *                        document before returning
- *    `options.depopulate` depopulate any populated paths, replacing them with 
+ *    `options.depopulate` depopulate any populated paths, replacing them with
  *                         their original refs (defaults to false)
  *    `options.versionKey` whether to include the version key (defaults to true)
- *    `options.retainKeyOrder` keep the order of object keys. If this is set to 
- *                             true, Object.keys(new Doc({ a: 1, b: 2}).toObject()) 
+ *    `options.retainKeyOrder` keep the order of object keys. If this is set to
+ *                             true, Object.keys(new Doc({ a: 1, b: 2}).toObject())
  *                             will always produce ['a', 'b'] (defaults to false)
  * @return {Object}  The hook object with the result as a plain js object.
  */
 
-export let toObject = function(options = {}) {
+export let toObject = function(options = {}, dataField = 'data') {
   return function(hook) {
     // Only perform this if it's used as an after hook.
     if (hook.result) {
+      let data = hook.result[dataField] || hook.result;
+      let res;
+
       // Handle multiple mongoose models
-      if (Array.isArray(hook.result)) {
-        hook.result = hook.result.map((obj) => {
+      if (Array.isArray(data)) {
+        res = data.map((obj) => {
           if (typeof obj.toObject === 'function') {
             return obj.toObject(options);
           }
@@ -40,8 +43,16 @@ export let toObject = function(options = {}) {
         });
       }
       // Handle single mongoose models
-      else if (typeof hook.result.toObject === 'function') {
-        hook.result = hook.result.toObject(options);
+      else if (typeof data.toObject === 'function') {
+        res = data.toObject(options);
+      }
+      // If our data is transformed set it to appropriate location on the hook
+      if (res) {
+        if (hook.result[dataField]) {
+          hook.result[dataField] = res;
+        } else {
+          hook.result = res;
+        }
       }
     }
   };

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -49,16 +49,16 @@ describe('Feathers Mongoose Hooks', () => {
         users = [user1, user2];
       });
 
-      it('converts arrays of mongoose models', () => {
+      it('converts paginated arrays of mongoose models', () => {
         let hook = {
-          result: users
+          result: { data: users }
         };
 
         hooks.toObject()(hook);
         expect(users[0].toObject).to.be.calledOnce;
         expect(users[1].toObject).to.be.calledOnce;
-        expect(hook.result[0]).to.deep.equal({ name: 'Jerry', age: 23});
-        expect(hook.result[1]).to.deep.equal({ name: 'Mary', age: 32});
+        expect(hook.result.data[0]).to.deep.equal({ name: 'Jerry', age: 23});
+        expect(hook.result.data[1]).to.deep.equal({ name: 'Mary', age: 32});
       });
 
       it('converts a single mongoose model', () => {
@@ -70,10 +70,22 @@ describe('Feathers Mongoose Hooks', () => {
         expect(users[0].toObject).to.be.calledOnce;
         expect(hook.result).to.deep.equal({ name: 'Jerry', age: 23});
       });
+
+      it('converts non-paginated arrays of mongoose models', () => {
+        let hook = {
+          result: users
+        };
+
+        hooks.toObject()(hook);
+        expect(users[0].toObject).to.be.calledOnce;
+        expect(users[1].toObject).to.be.calledOnce;
+        expect(hook.result[0]).to.deep.equal({ name: 'Jerry', age: 23});
+        expect(hook.result[1]).to.deep.equal({ name: 'Mary', age: 32});
+      });
     });
 
     describe('when results are plain object(s)', () => {
-      let user1, user2;
+      let user1, user2, users;
 
       beforeEach(() => {
         user1 = {
@@ -85,14 +97,26 @@ describe('Feathers Mongoose Hooks', () => {
           name: 'Mary',
           age: 32
         };
+
+        users = [user1, user2];
       });
 
-      it('does not convert arrays of objects', () => {
+      it('does not convert paginated arrays of objects', () => {
         let hook = {
-          result: [user1, user2]
+          result: { data: users }
         };
 
         hooks.toObject()(hook);
+        expect(hook.result.data[0]).to.deep.equal(user1);
+        expect(hook.result.data[1]).to.deep.equal(user2);
+      });
+
+      it('does not convert non-paginated arrays of objects', () => {
+        let hook = {
+          result: users
+        };
+
+        hooks.toObject({}, null)(hook);
         expect(hook.result[0]).to.deep.equal(user1);
         expect(hook.result[1]).to.deep.equal(user2);
       });


### PR DESCRIPTION
Fixes #77

This adds a second parameter to the `toObject` hook called `dataField` that defaults to `data`. It then checks if this field exists on `hook.result` and if so, will apply the mongoose transform to that array / object (thereby fixing pagination). Has the nice effect of not breaking anyone's current code, and working out of the box for the most typical cases of data either being on `hook.result` or `hook.result.data`.

Also changed to rimraf.