### PR TITLE
Wrapping native mongoldb errors. Specifically duplicate key errors.

### DIFF
--- a/src/error-handler.js
+++ b/src/error-handler.js
@@ -3,7 +3,7 @@ import errors from 'feathers-errors';
 export default function errorHandler(error) {
   let feathersError = error;
 
-  if (error.constructor.name === 'MongooseError' && error.name) {
+  if (error.name) {
     switch(error.name) {
       case 'ValidationError':
       case 'ValidatorError':
@@ -17,6 +17,14 @@ export default function errorHandler(error) {
       case 'MissingSchemaError':
       case 'DivergentArrayError':
         feathersError = new errors.GeneralError(error);
+        break;
+      case 'MongoError':
+        if (error.code === 11000) {
+          feathersError = new errors.BadRequest(error);
+        }
+        else {
+          feathersError = new errors.GeneralError(error);
+        }
         break;
     }
   }

--- a/test/error-handler.test.js
+++ b/test/error-handler.test.js
@@ -98,4 +98,14 @@ describe('Feathers Mongoose Error Handler', () => {
       done();
     }).catch(done);
   });
+
+  it('wraps a DuplicateKey error as a BadRequest', done => {
+    let e = Error('Mock Duplicate Key Error');
+    e.name = 'MongoError';
+    e.code = 11000;
+    errorHandler(e).catch(error => {
+      expect(error).to.be.an.instanceof(errors.BadRequest);
+      done();
+    }).catch(done);
+  });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -163,6 +163,7 @@ describe('Feathers Mongoose Service', () => {
     it('returns a BadRequest when unique index is violated', function(done) {
       pets.create({ type: 'cat', name: 'Bob' })
         .then(() => pets.create({ type: 'cat', name: 'Bob' }))
+        .then(() => done(new Error('Should not be successful')))
         .catch(error => {
           expect(error.name).to.equal('BadRequest');
           done();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -159,6 +159,15 @@ describe('Feathers Mongoose Service', () => {
           done();
         });
     });
+
+    it('returns a BadRequest when unique index is violated', function(done) {
+      pets.create({ type: 'cat', name: 'Bob' })
+        .then(() => pets.create({ type: 'cat', name: 'Bob' }))
+        .catch(error => {
+          expect(error.name).to.equal('BadRequest');
+          done();
+        });
+    });
   });
 
   describe('Lean Services', () => {

--- a/test/models/pet.js
+++ b/test/models/pet.js
@@ -3,7 +3,7 @@ const Schema = mongoose.Schema;
 
 const PetSchema = new Schema({
   type: {type: String, required: true},
-  name: {type: String, required: true}
+  name: {type: String, required: true, unique: true}
 });
 
 const PetModel = mongoose.model('Pet', PetSchema);


### PR DESCRIPTION
This is so that they behave normally and don't expose info they shouldn't.