### PR TITLE
Return NotFound when id is invalid ObjectID on get

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "feathers-errors": "^2.0.1",
     "feathers-query-filters": "^2.0.0",
     "lodash.omit": "^4.3.0",
-    "uberproto": "^1.2.0"
+    "uberproto": "^1.2.0",
+    "mongodb": "^2.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.2",

--- a/src/service.js
+++ b/src/service.js
@@ -3,6 +3,7 @@ import Proto from 'uberproto';
 import filter from 'feathers-query-filters';
 import errors from 'feathers-errors';
 import errorHandler from './error-handler';
+import { ObjectID } from 'mongodb';
 
 // Create the service.
 class Service {
@@ -95,6 +96,10 @@ class Service {
   }
 
   _get(id, params) {
+    if (!ObjectID.isValid(id)) {
+      throw new errors.NotFound(`No record found for id '${id}'`);
+    }
+
     let modelQuery = this
       .Model
       .findOne({ [this.id]: id });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -216,6 +216,10 @@ describe('Feathers Mongoose Service', () => {
           done();
         });
     });
+
+    it('returns a NotFound when id is invalid ObjectID on get', () => {
+      expect(function() { people.get('1234', {}); }).to.throw(errors.NotFound, `No record found for id '1234'`);
+    });
   });
 
   describe('Lean Services', () => {


### PR DESCRIPTION
According to issue #102, on get when id is invalid ObjectID (ex. `GET localhost/mymodels/1234`), instead of returning `400 Bad Request`, this fix returns `404 NotFound`.