### PR TITLE
Adds the posibility to send an object to the $select

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -40,6 +40,10 @@ class Service {
       }
 
       q.select(fields);
+    } else {
+      if(filters.$select && typeof filters.$select === 'object') {
+        q.select(filters.$select);
+      }
     }
 
     // Handle $sort


### PR DESCRIPTION
Sometime we need to add an object to a select, in the case of using full text search with weight in mongoose

example:

```javascript
Model
    .find(
        { $text : { $search : "text to look for" } }, 
        { score : { $meta: "textScore" } }
    )
    .sort({ score : { $meta : 'textScore' } })
    .exec(function(err, results) {
        // callback
    });
```

with this change allow me to do this in a hook

```javascript
if (hook.params.query.q) {
    hook.params.query.$text = {
        $search: hook.params.query.q
    }
    hook.params.query.$select = {
        score: {
            $meta: "textScore"
        }
    };
    hook.params.query.$sort = {
        score: {
            $meta: 'textScore'
        }
    };
    delete hook.params.query.q;
}
```