### PR TITLE
Update service.js for limit query results according to criteria when get doc by _id

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -111,10 +111,14 @@ class Service {
 
   _get (id, params = {}) {
     params.query = params.query || {};
+    const _query = Object.assign({}, params.query);
+    delete _query.$populate;
+    delete _query.$select;
+    _query[this.id]= id;
 
     let modelQuery = this
       .Model
-      .findOne({ [this.id]: id });
+      .findOne(_query);
 
     // Handle $populate
     if (params.query.$populate) {


### PR DESCRIPTION
For some time, we need to qualify the user according the _id to take data:
Users can only access data associated with own, rather than just use an _id then can get the data.
This is useful in the management system.

So we hope that, when according _id to get the data,
using some criteria in params.query to limit the query result.

Thanks.