### PR TITLE
Allow $select to catch and use string syntax

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -37,7 +37,7 @@ class Service {
     const q = this.Model.find(query).lean(this.lean);
 
     // $select uses a specific find syntax, so it has to come first.
-    if(typeof filters.$select === 'string') {
+    if (typeof filters.$select === 'string') {
       var fields = filters.$select;
     } else if (filters.$select && filters.$select.length) {
       let fields = {};

--- a/src/service.js
+++ b/src/service.js
@@ -38,7 +38,8 @@ class Service {
 
     // $select uses a specific find syntax, so it has to come first.
     if (typeof filters.$select === 'string') {
-      var fields = filters.$select;
+      let fields = filters.$select;
+      q.select(fields);
     } else if (filters.$select && filters.$select.length) {
       let fields = {};
 

--- a/src/service.js
+++ b/src/service.js
@@ -37,7 +37,9 @@ class Service {
     const q = this.Model.find(query).lean(this.lean);
 
     // $select uses a specific find syntax, so it has to come first.
-    if (filters.$select && filters.$select.length) {
+    if(typeof filters.$select === 'string') {
+      var fields = filters.$select;
+    } else if (filters.$select && filters.$select.length) {
       let fields = {};
 
       for (let key of filters.$select) {

--- a/src/service.js
+++ b/src/service.js
@@ -37,10 +37,7 @@ class Service {
     const q = this.Model.find(query).lean(this.lean);
 
     // $select uses a specific find syntax, so it has to come first.
-    if (typeof filters.$select === 'string') {
-      let fields = filters.$select;
-      q.select(fields);
-    } else if (filters.$select && filters.$select.length) {
+    if (Array.isArray(filters.$select)) {
       let fields = {};
 
       for (let key of filters.$select) {
@@ -48,10 +45,8 @@ class Service {
       }
 
       q.select(fields);
-    } else {
-      if (filters.$select && typeof filters.$select === 'object') {
-        q.select(filters.$select);
-      }
+    } else if (typeof filters.$select === 'string' || typeof filters.$select === 'object') {
+      q.select(filters.$select);
     }
 
     // Handle $sort

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,7 +107,7 @@ describe('Feathers Mongoose Service', () => {
     beforeEach(() => {
       // FIXME (EK): This is shit. We should be loading fixtures
       // using the raw driver not our system under test
-      return pets.create({type: 'dog', name: 'Rufus'}).then(pet => {
+      return pets.create({type: 'dog', name: 'Rufus', gender: 'Unknown'}).then(pet => {
         _petIds.Rufus = pet._id;
 
         return people.create({
@@ -124,6 +124,48 @@ describe('Feathers Mongoose Service', () => {
       return pets.remove(null, { query: {} }).then(() =>
         people.remove(null, { query: {} })
       );
+    });
+
+    it('can $select with a String', function (done) {
+      var params = {
+        query: {
+          name: 'Rufus',
+          $select: '+gender'
+        }
+      };
+
+      pets.find(params).then(data => {
+        expect(data[0].gender).to.equal('Unknown');
+        done();
+      });
+    });
+
+    it('can $select with an Array', function (done) {
+      var params = {
+        query: {
+          name: 'Rufus',
+          $select: ['gender']
+        }
+      };
+
+      pets.find(params).then(data => {
+        expect(data[0].gender).to.equal('Unknown');
+        done();
+      });
+    });
+
+    it('can $select with an Object', function (done) {
+      var params = {
+        query: {
+          name: 'Rufus',
+          $select: {'gender': true}
+        }
+      };
+
+      pets.find(params).then(data => {
+        expect(data[0].gender).to.equal('Unknown');
+        done();
+      });
     });
 
     it('can $populate with find', function (done) {

--- a/test/models/pet.js
+++ b/test/models/pet.js
@@ -3,7 +3,8 @@ const Schema = mongoose.Schema;
 
 const PetSchema = new Schema({
   type: {type: String, required: true},
-  name: {type: String, required: true, unique: true}
+  name: {type: String, required: true, unique: true},
+  gender: {type: String, required: false, select: false}
 });
 
 const PetModel = mongoose.model('Pet', PetSchema);


### PR DESCRIPTION
mongoose allows a string to be passed to the `.select()` function ie. `select('+someExtraField')`. 

Using this syntax allows you to keep all existing fields selected, but select additional fields you might have hidden in your schema by using `select: false` as a "column/field" option. It's also a more succinct and flexible way of passing the select information IMHO.

I hope that this change will allow the other forms to be used, but allow this use case. 

I still need to check/write tests and clean up the code a bit, but getting this out early for concerns/comment.