### PR TITLE
Use toObject for create when lean is true

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -159,6 +159,7 @@ class Service {
 
   create (data, params) {
     return this.Model.create(data)
+      .then(result => (this.lean && result.toObject) ? result.toObject() : result)
       .then(select(params, this.id))
       .catch(errorHandler);
   }


### PR DESCRIPTION
Because `Model.create` always returns a Mongoose model (unlike all other queries).