### PR TITLE
Discriminated Model Support

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ import errors from 'feathers-errors';
 import feathers from 'feathers';
 import service, { hooks, Service } from '../src';
 import server from './test-app';
-import { User, Pet, Peeps, CustomPeeps } from './models';
+import { User, Pet, Peeps, CustomPeeps, Post, TextPost } from './models';
 
 const _ids = {};
 const _petIds = {};
@@ -18,11 +18,13 @@ const app = feathers()
   .use('/people', service({ Model: User, lean: false }))
   .use('/pets', service({ Model: Pet, lean: false }))
   .use('/people2', service({ Model: User }))
-  .use('/pets2', service({ Model: Pet }));
+  .use('/pets2', service({ Model: Pet }))
+  .use('/posts', service({ Model: Post, discriminators: [TextPost] }));
 const people = app.service('people');
 const pets = app.service('pets');
 const leanPeople = app.service('people2');
 const leanPets = app.service('pets2');
+const posts = app.service('posts');
 
 let testApp;
 
@@ -362,6 +364,97 @@ describe('Feathers Mongoose Service', () => {
         expect(data.pets[0].name).to.equal('Rufus');
         done();
       }).catch(done);
+    });
+  });
+
+  describe('Discriminators', () => {
+    const data = {
+      _type: 'text',
+      text: 'Feathers!!!'
+    };
+
+    afterEach(done => {
+      posts.remove(null, { query: {} })
+      .then(data => {
+        done();
+      });
+    });
+
+    it('can get a discriminated model', function (done) {
+      posts.create(data)
+      .then(data => posts.get(data._id))
+      .then(data => {
+        expect(data._type).to.equal('text');
+        expect(data.text).to.equal('Feathers!!!');
+        done();
+      });
+    });
+
+    it('can find discriminated models by the type', function (done) {
+      posts.create(data)
+      .then(data => posts.find({ query: { _type: 'text' } }))
+      .then(data => {
+        data.forEach(element => {
+          expect(element._type).to.equal('text');
+        });
+        done();
+      });
+    });
+
+    it('can create a discriminated model', function (done) {
+      posts.create(data)
+      .then(data => {
+        expect(data._type).to.equal('text');
+        expect(data.text).to.equal('Feathers!!!');
+        done();
+      });
+    });
+
+    it('can update a discriminated model', function (done) {
+      const update = {
+        _type: 'text',
+        text: 'Hello, world!',
+        createdAt: Date.now(),
+        updatedAt: Date.now()
+      };
+      const params = {
+        query: {
+          _type: 'text'
+        }
+      };
+      posts.create(data)
+      .then(data => posts.update(data._id, update, params))
+      .then(data => {
+        expect(data._type).to.equal('text');
+        expect(data.text).to.equal('Hello, world!');
+        done();
+      });
+    });
+
+    it('can patch a discriminated model', function (done) {
+      const update = {
+        text: 'Howdy folks!'
+      };
+      const params = {
+        query: {
+          _type: 'text'
+        }
+      };
+      posts.create(data)
+      .then(data => posts.patch(data._id, update, params))
+      .then(data => {
+        expect(data.text).to.equal('Howdy folks!');
+        done();
+      });
+    });
+
+    it('can remove a discriminated model', function (done) {
+      posts.create(data)
+      .then(data => posts.remove(data._id, { query: { _type: 'text' } }))
+      .then(data => {
+        expect(data._type).to.equal('text');
+        done();
+      });
     });
   });
 

--- a/test/models/index.js
+++ b/test/models/index.js
@@ -2,7 +2,9 @@ import Pet from './pet';
 import User from './user';
 import Peeps from './peeps';
 import CustomPeeps from './peeps-customid';
+import Post from './post';
+import TextPost from './text-post';
 
 export default {
-  Pet, User, Peeps, CustomPeeps
+  Pet, User, Peeps, CustomPeeps, Post, TextPost
 };

--- a/test/models/post.js
+++ b/test/models/post.js
@@ -1,0 +1,17 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var options = {
+  discriminatorKey: '_type'
+};
+
+var PostSchema = new Schema({
+  createdAt: {type: Date, 'default': Date.now},
+  updatedAt: {type: Date, 'default': Date.now}
+}, options);
+
+PostSchema.index({'updatedAt': -1, background: true});
+
+var PostModel = mongoose.model('Post', PostSchema);
+
+module.exports = PostModel;

--- a/test/models/text-post.js
+++ b/test/models/text-post.js
@@ -1,0 +1,17 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+var Post = require('./post');
+
+var options = {
+  discriminatorKey: '_type'
+};
+
+var TextPostSchema = new Schema({
+  text: { type: String, default: null }
+}, options);
+
+TextPostSchema.index({'updatedAt': -1, background: true});
+
+var TextPostModel = Post.discriminator('text', TextPostSchema);
+
+module.exports = TextPostModel;


### PR DESCRIPTION
This PR adds support for discriminated models in Mongoose. Consumers of the API can now pass an additional `discriminators` option with a list of Mongoose models. The service will parse the `discriminatorKey` of the root model out of query and data params and swap out the root model with a discriminated instance if appropriate.