### PR TITLE
Handle upserts with patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ Session.vim
 # === Webstorm ===
 .idea
 
+# === Visual Studio Code ===
+.vscode
+
 # Users Environment Variables
 .lock-wscript
 

--- a/src/service.js
+++ b/src/service.js
@@ -263,11 +263,11 @@ class Service {
         .then(idList => {
           // Create a new query that re-queries all ids that
           // were originally changed
-          const findParams = Object.assign({}, params, {
+          const findParams = idList.length ? Object.assign({}, params, {
             query: {
               [this.id]: { $in: idList }
             }
-          });
+          }) : params;
 
           if (params.query && params.query.$populate) {
             findParams.query.$populate = params.query.$populate;
@@ -281,7 +281,9 @@ class Service {
             .update(omit(query, '$populate'), data, options)
             .lean(this.lean)
             .exec()
-            .then(() => this._getOrFind(id, findParams));
+            .then(() => {
+              return this._getOrFind(id, findParams);
+            });
         })
         .then(select(params, this.id))
         .catch(errorHandler);

--- a/src/service.js
+++ b/src/service.js
@@ -281,9 +281,7 @@ class Service {
             .update(omit(query, '$populate'), data, options)
             .lean(this.lean)
             .exec()
-            .then(() => {
-              return this._getOrFind(id, findParams);
-            });
+            .then(() => this._getOrFind(id, findParams));
         })
         .then(select(params, this.id))
         .catch(errorHandler);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -217,6 +217,22 @@ describe('Feathers Mongoose Service', () => {
       }).catch(done);
     });
 
+    it('can upsert with patch', function (done) {
+      var data = { name: 'Henry', age: 300 };
+      var params = {
+        mongoose: { upsert: true },
+        query: { name: 'Henry' }
+      };
+
+      people.patch(null, data, params).then(data => {
+        expect(Array.isArray(data)).to.equal(true);
+
+        var henry = data[0];
+        expect(henry.name).to.equal('Henry');
+        done();
+      }).catch(done);
+    });
+
     it('can $populate with update', function (done) {
       var params = {
         query: {
@@ -365,6 +381,22 @@ describe('Feathers Mongoose Service', () => {
 
       leanPeople.get(_ids.Doug, params).then(data => {
         expect(data.pets[0].name).to.equal('Rufus');
+        done();
+      }).catch(done);
+    });
+
+    it('can upsert with patch', function (done) {
+      var data = { name: 'Henry', age: 300 };
+      var params = {
+        mongoose: { upsert: true },
+        query: { name: 'Henry' }
+      };
+
+      leanPeople.patch(null, data, params).then(data => {
+        expect(Array.isArray(data)).to.equal(true);
+
+        var henry = data[0];
+        expect(henry.name).to.equal('Henry');
         done();
       }).catch(done);
     });


### PR DESCRIPTION
This allows `patch` to work properly for upserts.  I had to change the `findParams` to match the original query for cases where the documents don't exist, already.

```js
var data = { name: 'Henry', age: 300 };
var params = {
  mongoose: { upsert: true },
  query: { name: 'Henry' }
};

people.patch(null, data, params)
```

I've also checked in a Visual Studio Code launch config that enables really nice debugging of the mocha tests with babel support.  @ekryski you need to try it out, if you haven't, yet.  Just open the project in Visual Studio Code, set a break point somewhere in a test, open the debug panel and press play.